### PR TITLE
MSAWS-113 fixed policy document

### DIFF
--- a/awsconfig/json/awsconfig_setup_policy.json
+++ b/awsconfig/json/awsconfig_setup_policy.json
@@ -89,7 +89,7 @@
         {
             "Effect": "Allow",
             "Action": "sns:Publish",
-            "Resource": "arn:aws:sns:*"
+            "Resource": "arn:aws:sns:::*"
         }
     ]
 }


### PR DESCRIPTION
updated policy document that causes a failure during creating a role when enabling AWSConfig. This was an issue only for certain AWS accounts.