### PR TITLE
Change the federate role assume policy document

### DIFF
--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -102,36 +102,43 @@ function addStatement(input, callback) {
 }
 
 function removeStatement(input, callback) {
-  var assumeDoc = input.assumeDoc;
-  var federationRoleName = input.federationRoleName;
-  var lambdaRoleArn = input.roleArn;
-  console.log(assumeDoc.Statement);
-  console.log(input.roleArn);
-  var found = -1;
-  var assumeStatement = assumeDoc.Statement[0].Principal.AWS;
-  for (var i = 0; i < assumeStatement.length; i++) {
-    if (assumeStatement[i] == lambdaRoleArn) {
-      found = i;
-      break;
+    var assumeDoc = input.assumeDoc;
+    var federationRoleName = input.federationRoleName;
+    var lambdaRoleArn = input.roleArn;
+    console.log(assumeDoc.Statement);
+    console.log(input.roleArn);
+    var found = -1;
+    for (var i = 0; i < assumeDoc.Statement.length; i++) {
+        if (assumeDoc.Statement[i].Principal.AWS == lambdaRoleArn) {
+            found = i;
+            break;
+        }
     }
-  }
-  if (found < 0) {
-      for (var i = 0; i < assumeDoc.Statement.length; i++) {
-          if (assumeDoc.Statement[i].Principal.AWS == lambdaRoleArn) {
-              found = i;
-              break;
-          }
-      }
-  }
-  if (found >= 0) {
-    assumeStatement.splice(found, 1);
-    console.log(assumeStatement);
-    updateAssumeRolePolicy(input, callback);
-  }
-  else {
-    console.log("policy was already removed from 'federate' role for '" + lambdaRoleArn + "'");
-    callback(null, true);
-  }
+    if (found >= 0) {
+        assumeDoc.Statement.splice(found, 1);
+        console.log(assumeDoc.Statement);
+        updateAssumeRolePolicy(input, callback);
+    }
+    else {
+        //check if the policy is in the array
+        for (var j = 0; j < assumeDoc.Statement.length; j++) {
+            var assumeStatement = assumeDoc.Statement[j].Principal.AWS;
+            for (var i = 0; i < assumeStatement.length; i++) {
+                if (assumeStatement[i] == lambdaRoleArn) {
+                    found = i;
+                    break;
+                }
+            }
+        }
+        if (found >= 0) {
+            assumeStatement.splice(found, 1);
+            console.log(assumeStatement);
+            updateAssumeRolePolicy(input, callback);
+        }else {
+            console.log("policy was already removed from 'federate' role for '" + lambdaRoleArn + "'");
+            callback(null, true);
+        }
+    }
 }
 
 function updateAssumeRolePolicy(input, callback) {

--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -115,6 +115,7 @@ function removeStatement(input, callback) {
             break;
         }
     }
+
     if (found == -1) {
         var statement = assumeDoc.Statement[0].Principal.AWS;
         for (var k = 0; k < statement.length; k++) {
@@ -125,30 +126,21 @@ function removeStatement(input, callback) {
             }
         }
     }
-    if (found >= 0) {
-        console.log(assumeDoc.Statement);
-        //check before updating if there is a malformed arn
-        for (var i = 0; i < assumeDoc.Statement.length; i++) {
-            var statement = assumeDoc.Statement[i].Principal.AWS;
-            if (! statement == "*" && typeof(statement) == "string" && ! statement.startsWith("arn:aws:iam::")){
-                assumeDoc.Statement.splice(i,1);
-            }else{
-                for (var k = 0; k < statement.length; k++) {
-                    if (! statement == "*" && typeof(statement[k]) == "string" && ! statement[k].startsWith("arn:aws:iam::")) {
-                        statement.splice(k, 1);
-                    }
-                }
+
+    //check before updating if there is a malformed arn
+    for (var i = 0; i < assumeDoc.Statement.length; i++) {
+        var statement = assumeDoc.Statement[i].Principal.AWS;
+        if(typeof(statement) == "string"){
+            if (statement != "*" && !statement.startsWith("arn:aws:iam::")) assumeDoc.Statement.splice(i,1);
+        }
+        else if(typeof(statement) == "object"){
+            for (var k = 0; k < statement.length; k++) {
+                if (statement != "*" && !statement[k].startsWith("arn:aws:iam::")) statement.splice(k, 1);
             }
         }
-        console.log("***********************************");
-        console.log(input.assumeDoc);
-        console.log("***********************************");
-        updateAssumeRolePolicy(input, callback);
     }
-    else {
-        console.log("policy was already removed from 'federate' role for '" + lambdaRoleArn + "'");
-        callback(null, true);
-    }
+    console.log(JSON.stringify(input.assumeDoc));
+    updateAssumeRolePolicy(input, callback);
 }
 
 

--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -67,6 +67,9 @@ function addStatement(input, callback) {
 
   console.log(assumeDoc.Statement);
   var statements = assumeDoc.Statement.filter(function(statement) {
+    if (! statement.Effect == 'Allow' && ! statement.Action == 'sts:AssumeRole'){
+        return false;
+    }
     var s = statement.Principal.AWS;
     if(typeof(s) == "string"){
         if(lambdaRoleArn == s) return true;

--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -65,7 +65,6 @@ function addStatement(input, callback) {
   var federationRoleName = input.federationRoleName;
   var lambdaRoleArn = input.roleArn;
 
-  console.log("*********************addStatement 111111111111111111 *************************");
   console.log(assumeDoc.Statement);
   var statements = assumeDoc.Statement.filter(function(statement) {
     var s = statement.Principal.AWS;
@@ -79,6 +78,7 @@ function addStatement(input, callback) {
         }
     }
   });
+
   console.log(statements.length);
   if (statements.length == 0) {
     // pick the first statement and append to it
@@ -88,7 +88,8 @@ function addStatement(input, callback) {
         assumeStatement = [assumeStatement];
     }
     assumeStatement.push(lambdaRoleArn);
-    console.log("assumeStatement = " + JSON.stringify(assumeStatement));
+    assumeDoc.Statement[0].Principal.AWS = assumeStatement;
+    console.log("assumeDoc = " + JSON.stringify(assumeDoc));
     updateAssumeRolePolicy(input, callback);
   }
   else {

--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -83,12 +83,12 @@ function addStatement(input, callback) {
   if (statements.length == 0) {
     // pick the first statement and append to it
     var assumeStatement = assumeDoc.Statement[0].Principal.AWS;
+
     if(typeof(assumeStatement) == "string"){
         assumeStatement = [assumeStatement];
     }
     assumeStatement.push(lambdaRoleArn);
-    console.log("*********************addStatement 222222222222222 *************************");
-    console.log(assumeDoc.Statement);
+    console.log("assumeStatement = " + JSON.stringify(assumeStatement));
     updateAssumeRolePolicy(input, callback);
   }
   else {
@@ -104,15 +104,16 @@ function removeStatement(input, callback) {
   console.log(assumeDoc.Statement);
   console.log(input.roleArn);
   var found = -1;
-  for (var i = 0; i < assumeDoc.Statement.length; i++) {
-    if (assumeDoc.Statement[i].Principal.AWS == lambdaRoleArn) {
+  var assumeStatement = assumeDoc.Statement[0].Principal.AWS;
+  for (var i = 0; i < assumeStatement.length; i++) {
+    if (assumeStatement[i] == lambdaRoleArn) {
       found = i;
       break;
     }
   }
   if (found >= 0) {
-    assumeDoc.Statement.splice(found, 1);
-    console.log(assumeDoc.Statement);
+    assumeStatement.splice(found, 1);
+    console.log(assumeStatement);
     updateAssumeRolePolicy(input, callback);
   }
   else {

--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -115,6 +115,14 @@ function removeStatement(input, callback) {
       break;
     }
   }
+  if (found < 0) {
+      for (var i = 0; i < assumeDoc.Statement.length; i++) {
+          if (assumeDoc.Statement[i].Principal.AWS == lambdaRoleArn) {
+              found = i;
+              break;
+          }
+      }
+  }
   if (found >= 0) {
     assumeStatement.splice(found, 1);
     console.log(assumeStatement);

--- a/cloudformation/iam_federation.js
+++ b/cloudformation/iam_federation.js
@@ -64,18 +64,30 @@ function addStatement(input, callback) {
   var assumeDoc = input.assumeDoc;
   var federationRoleName = input.federationRoleName;
   var lambdaRoleArn = input.roleArn;
-  var lambdaStatement = {
-    Sid: '',
-    Effect: 'Allow',
-    Principal: { AWS: lambdaRoleArn },
-    Action: 'sts:AssumeRole'
-  };
+
+  console.log("*********************addStatement 111111111111111111 *************************");
+  console.log(assumeDoc.Statement);
   var statements = assumeDoc.Statement.filter(function(statement) {
-    return statement.Principal.AWS == lambdaRoleArn;
+    var s = statement.Principal.AWS;
+    if(typeof(s) == "string"){
+        if(lambdaRoleArn == s) return true;
+        else return false;
+    }
+    for (var idx = 0 ; idx < s.length ; idx ++){
+        if (lambdaRoleArn == s[idx]){
+            return true;
+        }
+    }
   });
   console.log(statements.length);
   if (statements.length == 0) {
-    assumeDoc.Statement.push(lambdaStatement);
+    // pick the first statement and append to it
+    var assumeStatement = assumeDoc.Statement[0].Principal.AWS;
+    if(typeof(assumeStatement) == "string"){
+        assumeStatement = [assumeStatement];
+    }
+    assumeStatement.push(lambdaRoleArn);
+    console.log("*********************addStatement 222222222222222 *************************");
     console.log(assumeDoc.Statement);
     updateAssumeRolePolicy(input, callback);
   }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+account="442294194136"
+regions=("us-east-1" "us-west-2" "ap-southeast-1" "ap-southeast-2" "ap-northeast-1" "eu-central-1" "eu-west-1")
+
+awsconfig="awsconfig/build.f/particles-awsconfig/config/default.js"
+awsconfigrules="awsconfigrules/build.f/particles-awsconfigrules/config/default.js"
+
+tLen=${#regions[@]}
+
+for (( i=0; i<${tLen}; i++ ));
+do
+	echo $account
+	echo ${regions[$i]}
+	export AWS_REGION=${regions[$i]}
+	sed -i "/region: /c\        region: '${regions[$i]}'," $awsconfig
+	sed -i "/bucket: /c\        bucket: 'sgas.particles-awsconfig.$account.${regions[$i]}'" $awsconfig
+	sed -i "/region: /c\        region: '${regions[$i]}'," $awsconfigrules
+	sed -i "/bucket: /c\        bucket: 'sgas.test.particles-awsconfigrules.$account.${regions[$i]}'" $awsconfigrules
+	make build
+done
+


### PR DESCRIPTION
The changes would let add more policy documents in the federate role and would avoid ACL limit exceed issue which is 2048 characters as per AWS documentation.