### PR TITLE
Datadog/install agent/ma 2006

### DIFF
--- a/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
@@ -41,7 +41,7 @@
                 "source": { "Fn::Join" : [ "", ["https://s3.amazonaws.com/", { "Ref" : "HpsaBucket" }, "/Windows.ps1"]]}
             },
             "C:\\sungardas\\ddagent-cli-latest.msi": {
-                "source": "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi"
+                "source": {"Ref": "datadogAgentUrl"}
             }
         },
         "services" : {

--- a/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
@@ -1,6 +1,6 @@
 {
     "configSets": {
-        "default": ["install_cfn", "routes", "hpsaagentinstall", "rename", "bs_hardware"]
+        "default": ["install_cfn", "datadog", "routes", "hpsaagentinstall", "rename", "bs_hardware"]
     },
     "install_cfn" : {
         "files" : {

--- a/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
@@ -39,6 +39,9 @@
             },
             "C:\\sungardas\\Windows.ps1": {
                 "source": { "Fn::Join" : [ "", ["https://s3.amazonaws.com/", { "Ref" : "HpsaBucket" }, "/Windows.ps1"]]}
+            },
+            "C:\\sungardas\\ddagent-cli-latest.msi": {
+                "source": "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi"
             }
         },
         "services" : {
@@ -58,6 +61,25 @@
                 "waitAfterCompletion": 0
             }
         }
+    },
+    "datadog": {
+        "commands": {
+             "install datadog": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "msiexec /qn /i C:\\sungardas\\ddagent-cli-latest.msi APIKEY='",
+                      {
+                        "Ref": "datadogApiKey"
+                      },
+		      "' "
+                    ]
+                  ]
+                },
+                "waitAfterCompletion": 0
+              }
+            }
     },
     "routes": {
         "commands": {

--- a/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/cf_init.hbs
@@ -1,6 +1,6 @@
 {
     "configSets": {
-        "default": ["install_cfn", "datadog", "routes", "hpsaagentinstall", "rename", "bs_hardware"]
+        "default": ["install_cfn", "datadogSignatureCheck","datadog", "routes", "hpsaagentinstall", "rename", "bs_hardware"]
     },
     "install_cfn" : {
         "files" : {
@@ -61,6 +61,14 @@
                 "waitAfterCompletion": 0
             }
         }
+    },
+    "datadogSignatureCheck": {
+        "commands": {
+             "agent signature check": {
+                "command": { "Fn::Join" : ["", ["powershell.exe   $getAuthSig = Get-AuthenticodeSignature 'C:\\sungardas\\ddagent-cli-latest.msi' ; If($getAuthSig.Status -ne 'Valid') {throw $getAuthSig.path }"]] },
+                "waitAfterCompletion": 0
+             }
+         }
     },
     "datadog": {
         "commands": {

--- a/managed-os/build.f/particles-managed-os/particles/partials/linux_user_data.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/linux_user_data.hbs
@@ -37,7 +37,12 @@
                   "Ref": "Hostname"
                 },
 		" > /etc/hostname\n", 
-		"/opt/opsware/agent/pylibs/cog/bs_hardware\n",               
+		"/opt/opsware/agent/pylibs/cog/bs_hardware\n",
+                "DD_API_KEY=",
+                {
+                  "Ref": "datadogApiKey"
+                },
+                " bash -c \" $(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh) \" \n",
                 "/opt/aws/bin/cfn-init -v ",
                 " --stack ",
                 {

--- a/managed-os/build.f/particles-managed-os/particles/partials/linux_user_data.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/linux_user_data.hbs
@@ -38,7 +38,7 @@
                 },
 		" > /etc/hostname\n", 
 		"/opt/opsware/agent/pylibs/cog/bs_hardware\n",
-                "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\n
+                "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\n",
                 "enabled=1\ngpgcheck=1\npriority=1\n",
                 "gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n' > /etc/yum.repos.d/datadog.repo\n",
                 "$sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent || $sudo_cmd yum -y install datadog-agent\n",
@@ -46,7 +46,8 @@
                 {
                   "Ref": "datadogApiKey"
                 },
-                "/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf\"\n ",
+                "/' ",
+                "/etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf \"\n",
                 "/opt/aws/bin/cfn-init -v ",
                 " --stack ",
                 {

--- a/managed-os/build.f/particles-managed-os/particles/partials/linux_user_data.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/partials/linux_user_data.hbs
@@ -38,11 +38,15 @@
                 },
 		" > /etc/hostname\n", 
 		"/opt/opsware/agent/pylibs/cog/bs_hardware\n",
-                "DD_API_KEY=",
+                "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\n
+                "enabled=1\ngpgcheck=1\npriority=1\n",
+                "gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n' > /etc/yum.repos.d/datadog.repo\n",
+                "$sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent || $sudo_cmd yum -y install datadog-agent\n",
+                "$sudo_cmd sh -c \"sed 's/api_key:.*/api_key: ",
                 {
                   "Ref": "datadogApiKey"
                 },
-                " bash -c \" $(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh) \" \n",
+                "/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf\"\n ",
                 "/opt/aws/bin/cfn-init -v ",
                 " --stack ",
                 {

--- a/managed-os/build.f/particles-managed-os/particles/sets/parameters.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/sets/parameters.hbs
@@ -54,6 +54,11 @@
   type="String"
   description="Bucket Name where hpsa agent uploaded"
 }}
+{{
+  parameter "m:core" "base" logicalId="datadogApiKey"
+  type="String"
+  description="datadogApiKey api key "
+}}
 
 {{!-- parameter "m:core" "base" type="String" logicalId="SourceCidrForRDP"
   description="IP Cidr from which you are likely to RDP into the instances."

--- a/managed-os/build.f/particles-managed-os/particles/sets/parameters.hbs
+++ b/managed-os/build.f/particles-managed-os/particles/sets/parameters.hbs
@@ -59,6 +59,11 @@
   type="String"
   description="datadogApiKey api key "
 }}
+{{
+  parameter "m:core" "base" logicalId="datadogAgentUrl"
+  type="String"
+  description="datadog url from where agent will download "
+}}
 
 {{!-- parameter "m:core" "base" type="String" logicalId="SourceCidrForRDP"
   description="IP Cidr from which you are likely to RDP into the instances."


### PR DESCRIPTION
Purpose: Automate installation of DD agent for managed instances
‌
For more details Please refer this link : https://mountdiablo.jira.com/browse/MA-2006
Changes: API & Particles
‌
Integration testing/functional testing:
All managedos should have datadog agent
Unit Testing
Not Implemented
ES Lint:
Not Implemented