### PR TITLE
MA-2958/ added vgw tag for active transit vpc for creating new vpc

### DIFF
--- a/managed-vpc/build.f/particles-initial/particles/sets/managedvpc/vpngateway.hbs
+++ b/managed-vpc/build.f/particles-initial/particles/sets/managedvpc/vpngateway.hbs
@@ -1,10 +1,12 @@
 {{!-- VPN-GATEWAY --}}
 {{parameter "m:vpc" "vpc/id" logicalId="VpcId" description="ID of VPC"}}
 
+{{parameter "m:core" "base" type="String" logicalId="ActiveTransitVpcTag" description="Vgw transit vpc spoke tag name of Virtual Private Gateway"}}
+
 {{#resource "vpngateway" logicalId="VpnGateway" nameTag=(ref "NameTag") }}
   "Properties": {
     "Type": "ipsec.1",
-    "Tags" : [ { "Key" : "transitvpc:spoke", "Value" : "true" },{ "Key" : "Name", "Value" : {{helper "m:core" "propertyValue" nameTag}} } ]
+    "Tags" : [ { "Key" : {{ref "ActiveTransitVpcTag"}}, "Value" : "true" },{ "Key" : "Name", "Value" : {{helper "m:core" "propertyValue" nameTag}} } ]
   }
 {{/resource}}
 {{#resource logicalId="VpngatewayAttachment"}}


### PR DESCRIPTION
Created new PR to merge the reverted changes from develop branch for MA-2958 

Original PR: [SungardAS/aws-services#117]

Reverted PR : https://github.com/SungardAS/aws-services/pull/118

Purpose : 

Modify Managed VPC workflow to tag VGW(s) with specific tag 

 Changes:

Changed the vpngateway.hbs file to include vgw value of active transit vpc from sails API

Testing :  

Testing is done manually in development environment.



